### PR TITLE
Rename TorifukuFaucet to TapyrusFaucet

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -6,7 +6,7 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module TorifukuFaucet
+module TapyrusFaucet
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1


### PR DESCRIPTION
rantan removes torifuku, but it remains on config/application.rb .
Tapyrus is the greatest chain I've ever met.